### PR TITLE
fix(settings): correct STATICFILES_DIRS to remove missing folder warning

### DIFF
--- a/stunotesapp/settings.py
+++ b/stunotesapp/settings.py
@@ -93,8 +93,7 @@ STATIC_URL = '/static/'
 
 # App-level static + global static folder
 STATICFILES_DIRS = [
-    BASE_DIR / "notes" / "static",   # your app static (style.css etc.)
-    BASE_DIR / "staticfiles",           # your global folder (admin overrides, extra css/js)
+    BASE_DIR / "notes" / "static",   # your app static (style.css etc.)          # your global folder (admin overrides, extra css/js)
 ]
 
 # Where collected static files will go after running `collectstatic`


### PR DESCRIPTION
just removed BASE_DIR  "static_files", because it has no use